### PR TITLE
Add abap_wiki to Adjacent Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file lists **only newly added repositories** (or other catalog entries with
 
 Dates use the commit date from `git log` on `data/catalog.json`.
 
+## 2026-07-11
+
+- [`Gixsy95/abap_wiki`](https://github.com/Gixsy95/abap_wiki) — abap_wiki, an agent-driven engine turning SAP S/4HANA custom ABAP objects into citable Markdown/Obsidian knowledge for humans and AI agents, added under Adjacent Tools
+
 ## 2026-06-26
 
 - [`arc-mcp/arc-1/.claude-plugin`](https://github.com/arc-mcp/arc-1/tree/main/.claude-plugin) — ARC-1 Claude Code Plugin, bundling the ARC-1 MCP server and SAP ABAP development skills for Claude Code

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Know a project that belongs here? [Open an issue using the "Add new entry" templ
 
 | Name | Repository | Purpose | License | Stars | Last Change |
 | --- | --- | --- | --- | ---: | --- |
-| SAP Fiori MCP Server | [SAP/open-ux-tools/packages/fiori-mcp-server](https://github.com/SAP/open-ux-tools/tree/main/packages/fiori-mcp-server) | Fiori app generation and modification workflows. | Apache-2.0 | 151 | 2026-07-10 |
+| SAP Fiori MCP Server | [SAP/open-ux-tools/packages/fiori-mcp-server](https://github.com/SAP/open-ux-tools/tree/main/packages/fiori-mcp-server) | Fiori app generation and modification workflows. | Apache-2.0 | 152 | 2026-07-10 |
 | CAP MCP Server | [cap-js/mcp-server](https://github.com/cap-js/mcp-server) | AI-assisted CAP development with CDS-aware context. | Apache-2.0 | 101 | 2026-07-09 |
-| UI5 MCP Server | [UI5/mcp-server](https://github.com/UI5/mcp-server) | UI5-aware development support for OpenUI5 and SAPUI5. | Apache-2.0 | 89 | 2026-07-07 |
+| UI5 MCP Server | [UI5/mcp-server](https://github.com/UI5/mcp-server) | UI5-aware development support for OpenUI5 and SAPUI5. | Apache-2.0 | 90 | 2026-07-07 |
 | SAP MDK MCP Server | [SAP/mdk-mcp-server](https://github.com/SAP/mdk-mcp-server) | AI-assisted SAP Mobile Development Kit workflows. | Apache-2.0 | 33 | 2026-07-10 |
 | UI5 Web Components MCP Server | [UI5/webcomponents-mcp-server](https://github.com/UI5/webcomponents-mcp-server) | AI-assisted development with UI5 Web Components (component API, guidelines, docs). | Apache-2.0 | 19 | 2026-06-22 |
 | ADT MCP Server | [SAP Help Portal](https://help.sap.com/docs/abap-cloud/abap-development-tools-for-visual-studio-code/enabling-adt-mcp-server?locale=en-US) | Enables MCP clients to access ADT capabilities from ABAP Development Tools for Visual Studio Code. | **NO LICENSE FOUND** | - | - |
@@ -94,7 +94,7 @@ Know a project that belongs here? [Open an issue using the "Add new entry" templ
 | MCP ABAP ADT Server | [mario-andreschak/mcp-abap-adt](https://github.com/mario-andreschak/mcp-abap-adt) | ABAP system interaction via ADT APIs. | MIT | 157 | 2026-07-07 |
 | ARC-1 SAP ADT MCP Server | [arc-mcp/arc-1](https://github.com/arc-mcp/arc-1) | Secure-by-default, enterprise-ready SAP ABAP MCP server for developer IDEs, Microsoft Copilot, and any MCP client via BTP OAuth and the ADT REST API. | MIT | 138 | 2026-07-10 |
 | ABAP MCP Server SDK | [abap-ai/mcp](https://github.com/abap-ai/mcp) | Build MCP servers directly in ABAP. | MIT | 75 | 2026-06-14 |
-| mcp-abap-adt | [fr0ster/mcp-abap-adt](https://github.com/fr0ster/mcp-abap-adt) | ABAP ADT MCP server with CRUD and cloud/on-prem support. | MIT | 66 | 2026-07-05 |
+| mcp-abap-adt | [fr0ster/mcp-abap-adt](https://github.com/fr0ster/mcp-abap-adt) | ABAP ADT MCP server with CRUD and cloud/on-prem support. | MIT | 67 | 2026-07-05 |
 | ABAP Accelerator MCP Server | [aws-solutions-library-samples/guidance-for-deploying-sap-abap-accelerator-for-amazon-q-developer](https://github.com/aws-solutions-library-samples/guidance-for-deploying-sap-abap-accelerator-for-amazon-q-developer) | Enterprise-grade MCP server for SAP ABAP: create, test, document, and transform ABAP code via Amazon Q Developer and Kiro. | MIT-0 | 52 | 2026-05-08 |
 | BW Modeling MCP Server | [dnic-dev/bw-modeling-mcp](https://github.com/dnic-dev/bw-modeling-mcp) | Read, create, and modify SAP BW/4HANA objects directly in a live system via the internal BWMT REST API. | MIT | 46 | 2026-07-02 |
 | MCP server for SAP Cloudification Repository | [ClementRingot/sap-released-objects-mcp-server](https://github.com/ClementRingot/ROSA) | Gives AI agents real-time knowledge of which SAP objects are released for ABAP Cloud / Clean Core — and what to use instead when they're not. | MIT | 24 | 2026-07-06 |
@@ -208,10 +208,11 @@ Know a project that belongs here? [Open an issue using the "Add new entry" templ
 
 | Name | Repository | Purpose | License | Stars | Last Change |
 | --- | --- | --- | --- | ---: | --- |
-| ABAP Remote Filesystem for VS Code | [marcellourbani/vscode_abap_remote_fs](https://github.com/marcellourbani/vscode_abap_remote_fs) | Remote ABAP filesystem access in VS Code. | MIT | 333 | 2026-07-09 |
-| SAP CLI (sapcli) | [jfilak/sapcli](https://github.com/jfilak/sapcli) | Python CLI for SAP ADT and RFC operations: ABAP unit tests, ATC checks, transports, gCTS, abapGit install, and more. | Apache-2.0 | 94 | 2026-07-09 |
+| ABAP Remote Filesystem for VS Code | [marcellourbani/vscode_abap_remote_fs](https://github.com/marcellourbani/vscode_abap_remote_fs) | Remote ABAP filesystem access in VS Code. | MIT | 333 | 2026-07-11 |
+| SAP CLI (sapcli) | [jfilak/sapcli](https://github.com/jfilak/sapcli) | Python CLI for SAP ADT and RFC operations: ABAP unit tests, ATC checks, transports, gCTS, abapGit install, and more. | Apache-2.0 | 95 | 2026-07-09 |
 | CAP MCP Plugin | [gavdilabs/cap-mcp-plugin](https://github.com/gavdilabs/cap-mcp-plugin) | Generates MCP servers from CAP services. | Apache-2.0 | 62 | 2026-07-07 |
 | GitHub Copilot for Eclipse | [eclipse-copilot/eclipse-copilot](https://github.com/eclipse-copilot/eclipse-copilot) | GitHub Copilot integration plugin for Eclipse IDE. | EPL-2.0 | 32 | 2026-04-27 |
+| abap_wiki | [Gixsy95/abap_wiki](https://github.com/Gixsy95/abap_wiki) | Agent-driven engine that turns SAP S/4HANA custom ABAP objects into citable Markdown/Obsidian knowledge for humans and AI agents. | MIT | 28 | 2026-07-11 |
 | SAP TechEd 2025 CA261 Sample | [SAP-samples/teched2025-CA261](https://github.com/SAP-samples/teched2025-CA261) | Hands-on sample for AI + Fiori + MCP workflows. | Apache-2.0 | 12 | 2026-06-09 |
 | SAP Analytics Cloud MCP Server | [JumenEngels/sap_analytics_cloud_mcp](https://github.com/JumenEngels/sap_analytics_cloud_mcp) | Exposes SAP Analytics Cloud APIs as MCP tools. | MIT | 9 | 2026-03-02 |
 | SAP SuccessFactors MCP Server | [aiadiguru2025/sf-mcp](https://github.com/aiadiguru2025/sf-mcp) | SuccessFactors HR operations via MCP tools. | MIT | 9 | 2026-07-04 |

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -787,6 +787,13 @@
       "repo": "SAP-samples/teched2025-CA261",
       "purpose": "Hands-on sample for AI + Fiori + MCP workflows.",
       "notes": "Reference project, not a generic MCP server."
+    },
+    {
+      "type": "Community SAP",
+      "name": "abap_wiki",
+      "repo": "Gixsy95/abap_wiki",
+      "purpose": "Agent-driven engine that turns SAP S/4HANA custom ABAP objects into citable Markdown/Obsidian knowledge for humans and AI agents.",
+      "notes": "Uses an adversarial verification gate; optional live SAP access via MCP."
     }
   ],
   "referenceLinks": [

--- a/generated/catalog.enriched.json
+++ b/generated/catalog.enriched.json
@@ -1,7 +1,7 @@
 {
-  "generatedAt": "2026-07-11T06:45:30.255Z",
+  "generatedAt": "2026-07-11T19:01:37.171Z",
   "sourceCatalog": "data/catalog.json",
-  "repoCount": 86,
+  "repoCount": 87,
   "tokenUsed": true,
   "repoMetadata": {
     "1nbuc/mcp-integration-suite": {
@@ -480,7 +480,7 @@
       "exists": true,
       "fork": false,
       "parent": null,
-      "stars": 66,
+      "stars": 67,
       "lastChange": "2026-07-05T14:21:26Z",
       "archived": false,
       "license": "MIT",
@@ -514,6 +514,25 @@
         "JavaScript": 2821
       },
       "htmlUrl": "https://github.com/gavdilabs/cap-mcp-plugin"
+    },
+    "Gixsy95/abap_wiki": {
+      "repo": "Gixsy95/abap_wiki",
+      "source": "api",
+      "exists": true,
+      "fork": false,
+      "parent": null,
+      "stars": 28,
+      "lastChange": "2026-07-11T16:10:58Z",
+      "archived": false,
+      "license": "MIT",
+      "description": "Agent-driven SAP/ABAP knowledge base engine that turns S/4HANA custom objects into citable Markdown/Obsidian context for humans and AI agents.",
+      "primaryLanguage": "Python",
+      "languages": {
+        "Python": 812312,
+        "Shell": 7120,
+        "PowerShell": 6013
+      },
+      "htmlUrl": "https://github.com/Gixsy95/abap_wiki"
     },
     "gregorwolf/cloud-alm-itsm-mcp": {
       "repo": "gregorwolf/cloud-alm-itsm-mcp",
@@ -682,7 +701,7 @@
       "exists": true,
       "fork": false,
       "parent": null,
-      "stars": 94,
+      "stars": 95,
       "lastChange": "2026-07-09T22:11:16Z",
       "archived": false,
       "license": "Apache-2.0",
@@ -869,13 +888,13 @@
       "fork": false,
       "parent": null,
       "stars": 333,
-      "lastChange": "2026-07-09T11:37:48Z",
+      "lastChange": "2026-07-11T08:16:33Z",
       "archived": false,
       "license": "MIT",
       "description": "VS Code-based Agentic AI Platform for SAP ABAP Development",
       "primaryLanguage": "TypeScript",
       "languages": {
-        "TypeScript": 3672728,
+        "TypeScript": 3730884,
         "JavaScript": 113267,
         "HTML": 71326,
         "ABAP": 11300,
@@ -1386,7 +1405,7 @@
       "exists": true,
       "fork": false,
       "parent": null,
-      "stars": 151,
+      "stars": 152,
       "lastChange": "2026-07-10T16:53:47Z",
       "archived": false,
       "license": "Apache-2.0",
@@ -1495,7 +1514,7 @@
       "exists": true,
       "fork": false,
       "parent": null,
-      "stars": 89,
+      "stars": 90,
       "lastChange": "2026-07-07T14:34:45Z",
       "archived": false,
       "license": "Apache-2.0",


### PR DESCRIPTION
## What

Adds **[Gixsy95/abap_wiki](https://github.com/Gixsy95/abap_wiki)** (MIT, 28★) under **Adjacent SAP AI Developer Tools** — an agent-driven engine that turns SAP S/4HANA custom ABAP objects into citable Markdown/Obsidian knowledge for humans and AI agents, with an adversarial verification gate and optional live SAP access via MCP.

## Changes

- `data/catalog.json` — new `adjacentTools` entry
- `CHANGELOG.md` — new `2026-07-11` section
- `README.md` + `generated/catalog.enriched.json` — regenerated via `npm run build` (also picks up routine live-metadata refresh for a few existing repos, same as the daily job)

## Also done (not in this diff)

Issue #30 (`rahulsethi/SAP_AI_Core_Proxy`) was **closed** — the repo has no open-source license (no LICENSE file, none in README), which the list's rules disallow. Commented on the issue inviting resubmission once a license is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)